### PR TITLE
added get_hover_position function to the dbus interface

### DIFF
--- a/lib/DBus/Client.vala
+++ b/lib/DBus/Client.vala
@@ -307,5 +307,29 @@ namespace Plank
 			
 			return null;
 		}
+
+		/**
+		 * Gets the x and y position to display a hover window for a dock item. It also returns the position type of dock
+		 *
+		 * @param hovered the item that is hovered
+		 * @param x the resulting x position
+		 * @param y the resulting y position
+		 * @param dock_position the position type of the dock
+		 */
+		public bool get_hover_position (string uri, out int x, out int y, out Gtk.PositionType dock_position)
+		{
+			if (items_proxy == null) {
+				warning ("No proxy connected");
+				return false;
+			}
+			
+			try {
+				return items_proxy.get_hover_position (uri, out x, out y, out dock_position);
+			} catch (IOError e) {
+				warning (e.message);
+			}
+			
+			return false;
+		}
 	}
 }

--- a/lib/DBus/Interfaces.vala
+++ b/lib/DBus/Interfaces.vala
@@ -71,5 +71,15 @@ namespace Plank
 		 * @return the array of uris
 		 */
 		public abstract string[] get_transient_applications () throws GLib.IOError;
+
+		/**
+		 * Gets the x and y position to display a hover window for a dock item. It also returns the position type of dock
+		 *
+		 * @param hovered the item that is hovered
+		 * @param x the resulting x position
+		 * @param y the resulting y position
+		 * @param dock_position the position type of the dock
+		 */
+		public abstract bool get_hover_position (string uri, out int x, out int y, out Gtk.PositionType dock_position) throws GLib.IOError;
 	}
 }

--- a/lib/DBusManager.vala
+++ b/lib/DBusManager.vala
@@ -136,6 +136,25 @@ namespace Plank
 			
 			return result;
 		}
+
+		public bool get_hover_position (string uri, out int x, out int y, out Gtk.PositionType dock_position) {
+			
+			unowned ApplicationDockItemProvider? provider = (controller.default_provider as ApplicationDockItemProvider);
+			if (provider == null)
+				return false;
+			
+			unowned DockItem? item = provider.item_for_uri (uri);
+			if (item == null)
+				return false;
+				
+			unowned PositionManager? manager = controller.position_manager;
+			if (manager == null)
+				return false;
+			
+			manager.get_hover_position (item, out x, out y);
+			dock_position = manager.Position;
+			return true;
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Just to remind, this is my explanation from pull request at launchpad repo:
"Hi
I've created a Facebook Messenger desktop app which received very enthusiastic feedback (https://www.reddit.com/r/elementaryos/comments/6fml4c/desktop_app_for_facebook_messenger/). It shows conversations in chat bubbles anchored to the Plank dock. To do this, I had to add one function to Plank's D-Bus API - it just returns the result of get_menu_position.
I'd be very grateful if you accepted these changes - that would allow me to publish my app in the elementary's AppCenter."
Now the function returns the result of get_hover_position and current dock position type. It also uses out parameters instead of returning those weird arrays. Do you think it's OK now?