### PR TITLE
Fixed battery docklet

### DIFF
--- a/docklets/Battery/BatteryDockItem.vala
+++ b/docklets/Battery/BatteryDockItem.vala
@@ -25,10 +25,11 @@ namespace Docky
 	{
 		const string BAT_BASE_PATH = "/sys/class/power_supply";
 		const string BAT_CAPACITY = BAT_BASE_PATH + "/%s/capacity";
-		const string BAT_CAPACITY_LEVEL = BAT_BASE_PATH + "/%s/capacity_level";
+		//const string BAT_CAPACITY_LEVEL = BAT_BASE_PATH + "/%s/capacity_level";
 		const string BAT_STATUS = BAT_BASE_PATH + "/%s/status";
 		const string BAT_CHARGE_NOW = BAT_BASE_PATH + "/%s/charge_now";
 		const string BAT_ALARM = BAT_BASE_PATH + "/%s/alarm";
+		const uint BAT_CHECK_TIMER = 6000;
 
 		string current_battery = "BAT0";
 		uint timer_id = 0U;
@@ -47,7 +48,10 @@ namespace Docky
 			Text = _("No battery");
 			update ();
 
-			timer_id = Gdk.threads_add_timeout (60 * 1000, (SourceFunc) update);
+			// timer_id = Gdk.threads_add_timeout (60 * 1000, (SourceFunc) update);
+			// Replaced 60 * 1000 with const  BAT_CHECK_TIMER and lowered it to 60 * 100
+
+			timer_id = Gdk.threads_add_timeout (BAT_CHECK_TIMER, (SourceFunc) update); 
 		}
 
 		~BatteryDockItem ()
@@ -64,12 +68,14 @@ namespace Docky
 			return int.parse (s);
 		}
 
+		/*
 		string get_capacity_level () throws GLib.FileError
 		{
 			string s;
 			FileUtils.get_contents (BAT_CAPACITY_LEVEL.printf (current_battery), out s);
 			return s.strip ();
 		}
+		*/
 
 		string get_status () throws GLib.FileError
 		{
@@ -83,15 +89,19 @@ namespace Docky
 			try {
 				string new_icon;
 				var status = get_status ().down ();
+				//var capacity_level = get_capacity_level ().down ();
 				var capacity = get_capacity ();
-				var capacity_level = get_capacity_level ().down ();
+				
+				/*
 				switch (capacity_level) {
 					case "full":
 						new_icon = "battery-full";
 						break;
 					case "high":
-					case "normal":
 						new_icon = "battery-good";
+						break;
+					case "normal":
+						new_icon = "battery-medium";
 						break;
 					case "low":
 						new_icon = "battery-low";
@@ -106,6 +116,14 @@ namespace Docky
 						new_icon = "battery-missing";
 						break;
 				}
+				*/
+
+				if (capacity >= 95) { new_icon = "battery-full"; }
+				else if (capacity >= 70) { new_icon = "battery-good"; }
+				else if (capacity >= 35) { new_icon = "battery-medium"; }
+				else if (capacity >= 15) { new_icon = "battery-low"; }
+				else if (capacity > 1) { new_icon = "battery-caution"; }
+				else { new_icon = "battery-empty"; }
 
 				switch (status) {
 					case "charging":


### PR DESCRIPTION
I made a battery icon changeable basing on capacity: that's because capacity level never has the "High" status, the docklet was indicating "battery-good" icon until it became ~20% of capacity.
Now the distribution is:
* Capacity >= 95: battery-full icon;
* Capacity >= 70: battery-good icon;
* Capacity >= 35: battery-medium icon;
* Capacity >= 15: battery-low icon;
* Capacity > 1: battery-caution icon;
* Capacity <= 1: battery-empty icon.

I also made it updating every 6 seconds instead of 60.