### PR TITLE
Bug #1896297: Battery docklet hard coded to a battery that may not be…

### DIFF
--- a/docklets/Battery/BatteryPreferences.vala
+++ b/docklets/Battery/BatteryPreferences.vala
@@ -1,0 +1,39 @@
+//
+//  Copyright (C) 2011 Robert Dyer
+//
+//  This file is part of Plank.
+//
+//  Plank is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Plank is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Plank;
+
+namespace Docky
+{
+    public class BatteryPreferences : DockItemPreferences
+    {
+        [Description(nick = "battery-name", blurb = "The name of the battery unit under /sys/class/powe_supply (default=BAT0)")]
+        public string BatteryName {get;set;}
+
+        public BatteryPreferences.with_file (GLib.File file)
+        {
+            base.with_file (file);
+        }
+        
+        protected override void reset_properties ()
+        {
+            BatteryName = "BAT0";
+        }
+    }
+}

--- a/docklets/Battery/Makefile.am
+++ b/docklets/Battery/Makefile.am
@@ -12,6 +12,7 @@ libdocklet_battery_ladir = $(pkglibdir)/docklets
 libdocklet_battery_la_VALASOURCES = \
 	BatteryDockItem.vala \
 	BatteryDocklet.vala \
+	BatteryPreferences.vala \
 	$(NULL)
 
 nodist_libdocklet_battery_la_SOURCES = \


### PR DESCRIPTION
… present

This change makes the battery name user settable. The
next change will be to properly enumerate the batteries so that we do
not rely on user settings.