### PR TITLE
Fix for entries disappearing when updated

### DIFF
--- a/lib/Items/DockItem.vala
+++ b/lib/Items/DockItem.vala
@@ -318,17 +318,8 @@ namespace Plank
 				
 				load_from_launcher ();
 				break;
-			case FileMonitorEvent.MOVED:
-				if (other == null)
-					break;
-				var launcher = other.get_uri ();
-				Logger.verbose ("Launcher file '%s' moved to '%s'", f.get_uri (), launcher);
-				
-				replace_launcher (launcher);
-				
-				load_from_launcher ();
-				break;
 			case FileMonitorEvent.DELETED:
+			case FileMonitorEvent.MOVED_OUT:
 				debug ("Launcher file '%s' deleted, item is invalid now", f.get_uri ());
 				
 				launcher_exists = false;
@@ -338,6 +329,7 @@ namespace Plank
 				schedule_removal_if_needed ();
 				break;
 			case FileMonitorEvent.CREATED:
+			case FileMonitorEvent.MOVED_IN:
 				debug ("Launcher file '%s' created, item is valid again", f.get_uri ());
 				
 				launcher_exists = true;
@@ -345,7 +337,33 @@ namespace Plank
 				
 				stop_removal ();
 				break;
+			case FileMonitorEvent.RENAMED:
+				if (other == null)
+					break;
+
+				var launcher = other.get_uri ();
+
+				// Rename of launcher file to new name
+				if (launcher_exists) {
+					Logger.verbose ("Launcher file '%s' moved to '%s'", f.get_uri (), launcher);
+					
+					replace_launcher (launcher);
+					
+					load_from_launcher ();
+					break;
+				}
+
+				// Rename of temporary file to launcher name
+				debug ("Launcher file '%s' created from rename of '%s', item is valid again", launcher, f.get_uri ());
+				
+				launcher_exists = true;
+				State &= ~ItemState.INVALID;
+				
+				stop_removal ();
+				break;
+
 			default:
+				debug ("Unknown file monitor response");
 				break;
 			}
 			
@@ -366,7 +384,7 @@ namespace Plank
 			try {
 				var launcher_file = File.new_for_uri (launcher);
 				launcher_exists = launcher_file.query_exists ();
-				launcher_file_monitor = launcher_file.monitor_file (FileMonitorFlags.SEND_MOVED);
+				launcher_file_monitor = launcher_file.monitor_file (FileMonitorFlags.WATCH_MOVES);
 				launcher_file_monitor.changed.connect (launcher_file_changed);
 			} catch {
 				warning ("Unable to watch the launcher file '%s'", launcher);


### PR DESCRIPTION
Newer GLib has changed the semantics of the `FileMonitor`.
* Add newer `FileMonitor` semantics to fix entries disappearing after system updates, snap updates, or flatpak updates.

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>