### PR TITLE
Bug #1786509: Plank hides unexpectedly with autohide enabled in left or top positions

### DIFF
--- a/lib/HideManager.vala
+++ b/lib/HideManager.vala
@@ -411,7 +411,7 @@ namespace Plank
 				return Gdk.EVENT_PROPAGATE;
 			
 			if (Hovered)
-				update_hovered_with_coords (-1, -1);
+				update_hovered_with_coords ((int) event.x, (int) event.y);
 			
 			return Gdk.EVENT_PROPAGATE;
 		}


### PR DESCRIPTION
## Bug description

https://bugs.launchpad.net/plank/+bug/1786509
When plank is on the top or left position, autohide doesn't work as expected. Moving the mouse pointer along the edge of the screen causes plank to randomly hide and unhide itself (as shown in the video attached to the bug report, although unlike in the original bug report I can see this happen next to icons as well).
I've reproduced this on archlinux with xfce.

## Cause

`window.leave_notify_event` gets triggered sporadically (which calls `handle_leave_notify_event`) when the pointer is on the top or left edge of the screen.

## Changes

Changed the `update_hovered_with_coords` call in `handle_leave_notify_event` to pass the actual x and y coordinates instead of -1 as args. This ensures `Hovered` isn't set to false when `handle_leave_notify_event` is mistakenly called while the mouse pointer is actually within the dock 'window' area. Unhiding still works as normal otherwise.
